### PR TITLE
Fix pv image download free space check

### DIFF
--- a/nephoria/testcases/euca2ools/euca2ools_image_utils.py
+++ b/nephoria/testcases/euca2ools/euca2ools_image_utils.py
@@ -287,7 +287,7 @@ class Euca2oolsImageUtils(object):
                                  'is:{1}'.format(destpath, create_path))
 
         size = self.getHttpRemoteImageSize(image_url)
-        if (size <  machine.get_available(destpath, unit=self.__class__.gig)):
+        if (size > machine.get_available(destpath, unit=(self.gig/self.kb))):
             raise Exception("Not enough available space at: " +
                             str(destpath) + ", for image: " + str(image_url))
         timeout = size * time_per_gig


### PR DESCRIPTION
Fix image size check used with pv image load test. The size check was reversed and used incorrect kb to gb unit conversion.